### PR TITLE
Fix asset not being created properly when Stache watcher is disabled

### DIFF
--- a/src/Http/Controllers/GuestEntryController.php
+++ b/src/Http/Controllers/GuestEntryController.php
@@ -216,14 +216,15 @@ class GuestEntryController extends Controller
                 $path = substr($path, 1);
             }
 
-            // Create asset in Statamic
+            // Ensure asset is created in Statamic (otherwise, it won't show up in
+            // the Control Panel for sites with the Stache watcher disabled).
             $asset = Asset::make()
                 ->container($assetContainer->handle())
                 ->path($path);
 
             $asset->save();
 
-            // Add to array
+            // Push to the array
             $files[] = $path;
         }
 

--- a/src/Http/Controllers/GuestEntryController.php
+++ b/src/Http/Controllers/GuestEntryController.php
@@ -14,6 +14,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Statamic\Facades\Asset;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -202,11 +203,11 @@ class GuestEntryController extends Controller
 
         /* @var \Illuminate\Http\Testing\File $file */
         foreach ($uploadedFiles as $uploadedFile) {
-            $path = '/' . $uploadedFile->storeAs(
+            $path = '/'.$uploadedFile->storeAs(
                 isset($field->config()['folder'])
                     ? $field->config()['folder']
                     : '',
-                now()->timestamp . '-' . $uploadedFile->getClientOriginalName(),
+                now()->timestamp.'-'.$uploadedFile->getClientOriginalName(),
                 $assetContainer->diskHandle()
             );
 
@@ -215,6 +216,14 @@ class GuestEntryController extends Controller
                 $path = substr($path, 1);
             }
 
+            // Create asset in Statamic
+            $asset = Asset::make()
+                ->container($assetContainer->handle())
+                ->path($path);
+
+            $asset->save();
+
+            // Add to array
             $files[] = $path;
         }
 
@@ -267,7 +276,7 @@ class GuestEntryController extends Controller
     {
         if ($request->wantsJson()) {
             $data = array_merge($data, [
-                'status'  => 'success',
+                'status' => 'success',
                 'message' => null,
             ]);
 
@@ -283,7 +292,7 @@ class GuestEntryController extends Controller
     {
         if ($request->wantsJson()) {
             return response()->json([
-                'status'  => 'error',
+                'status' => 'error',
                 'message' => $errorMessage,
             ]);
         }


### PR DESCRIPTION
This pull request fixes #28 by creating an 'Asset' instance when a file is uploaded via the Guest Entries addon.

If you have the Stache watcher disabled and do a file upload, the asset would not be visible in the Control Panel until you refresh the Stache as Statamic doesn't know the asset was created.

When you have the Stache watcher enabled, it watches for files being created and so it adds the Asset to the Stache.