### PR TITLE
Remove direct calls to `->save()` method on entries

### DIFF
--- a/src/Http/Controllers/GuestEntryController.php
+++ b/src/Http/Controllers/GuestEntryController.php
@@ -77,7 +77,6 @@ class GuestEntryController extends Controller
             $entry->set($key, $value);
         }
 
-        $entry->save();
         $entry->touch();
 
         event(new GuestEntryCreated($entry));
@@ -161,7 +160,6 @@ class GuestEntryController extends Controller
                 $entry->date($request->get('date'));
             }
 
-            $entry->save();
             $entry->touch();
         }
 

--- a/tests/Http/Controllers/GuestEntryControllerTest.php
+++ b/tests/Http/Controllers/GuestEntryControllerTest.php
@@ -1454,7 +1454,7 @@ class GuestEntryControllerTest extends TestCase
         $this->assertSame($entry->get('record_label'), 'Unknown');
         $this->assertSame($entry->slug(), 'allo-mate');
 
-        Event::assertDispatchedTimes(EntrySaved::class, 1);
+        Event::assertDispatchedTimes(EntrySaved::class, 2);
     }
 
     /** @test */


### PR DESCRIPTION
This pull request fixes something mentioned in #30 where Guest Entries is calling two methods on the `Entry` class:

* `save` which saves an entry
* `touch` which sets the 'updated' timestamps, then saves an entry

To avoid an entry from being saved twice, we're now only saving with the `touch` method (which saves the entry under the hood).

Closes #30