### PR TITLE
Fix file uploads when Assets field is inside a Replicator

### DIFF
--- a/src/Http/Controllers/GuestEntryController.php
+++ b/src/Http/Controllers/GuestEntryController.php
@@ -105,20 +105,9 @@ class GuestEntryController extends Controller
             /** @var \Statamic\Fields\Field $blueprintField */
             $field = $entry->blueprint()->field($key);
 
-            if ($field && $field->fieldtype() instanceof AssetFieldtype) {
-                $value = $this->uploadFile($key, $field, $request);
-            }
-
-            if ($field && $field->fieldtype() instanceof DateFieldtype) {
-                $format = $field->fieldtype()->config(
-                    'format',
-                    strlen($value) > 10 ? $field->fieldtype()::DEFAULT_DATETIME_FORMAT : $field->fieldtype()::DEFAULT_DATE_FORMAT
-                );
-
-                $value = Carbon::parse($value)->format($format);
-            }
-
-            $data[$key] = $value;
+            $data[$key] = $field
+                ? $this->processField($field, $key, $value, $request)
+                : $value;
         }
 
         if ($entry->revisionsEnabled()) {

--- a/src/Http/Controllers/GuestEntryController.php
+++ b/src/Http/Controllers/GuestEntryController.php
@@ -19,7 +19,6 @@ use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site as SiteFacade;
-use Statamic\Fields\Blueprint;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Assets\Assets as AssetFieldtype;
 use Statamic\Fieldtypes\Date as DateFieldtype;

--- a/tests/Http/Controllers/GuestEntryControllerTest.php
+++ b/tests/Http/Controllers/GuestEntryControllerTest.php
@@ -462,8 +462,6 @@ class GuestEntryControllerTest extends TestCase
 
         Collection::make('comments')->save();
 
-        $this->withoutExceptionHandling();
-
         $this
             ->post(route('statamic.guest-entries.store'), [
                 '_collection' => 'comments',

--- a/tests/Http/Controllers/GuestEntryControllerTest.php
+++ b/tests/Http/Controllers/GuestEntryControllerTest.php
@@ -770,7 +770,7 @@ class GuestEntryControllerTest extends TestCase
     }
 
     /** @test */
-    public function can_store_entry_in_replicator_format()
+    public function can_store_entry_with_replicator_field()
     {
         Blueprint::make('comments')
             ->setNamespace('collections.comments')
@@ -847,7 +847,7 @@ class GuestEntryControllerTest extends TestCase
     }
 
     /** @test */
-    public function can_store_entry_in_replicator_format_with_file_upload()
+    public function can_store_entry_with_replicator_field_and_an_assets_field_inside_the_replicator()
     {
         AssetContainer::make('assets')->disk('local')->save();
 
@@ -1629,6 +1629,224 @@ class GuestEntryControllerTest extends TestCase
         $this->assertSame($entry->slug(), 'allo-mate');
 
         Event::assertDispatchedTimes(EntrySaved::class, 2);
+    }
+
+    /** @test */
+    public function can_update_entry_with_replicator_field()
+    {
+        Blueprint::make('albums')
+            ->setNamespace('collections.albums')
+            ->setContents([
+                'title' => 'Albums',
+                'sections' => [
+                    'main' => [
+                        'display' => 'main',
+                        'fields' => [
+                            [
+                                'handle' => 'title',
+                                'field' => [
+                                    'type' => 'text',
+                                ],
+                            ],
+                            [
+                                'handle' => 'artist',
+                                'field' => [
+                                    'type' => 'text',
+                                ],
+                            ],
+                            [
+                                'handle' => 'slug',
+                                'field' => [
+                                    'type' => 'slug',
+                                ],
+                            ],
+                            [
+                                'handle' => 'record_label',
+                                'field' => [
+                                    'type' => 'text',
+                                ],
+                            ],
+                            [
+                                'handle' => 'things',
+                                'field' => [
+                                    'sets' => [
+                                        'thing' => [
+                                            'display' => 'Thing',
+                                            'fields' => [
+                                                [
+                                                    'handle' => 'link',
+                                                    'field' => [
+                                                        'type' => 'text',
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                    'type' => 'replicator',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+            ->save();
+
+        Collection::make('albums')->save();
+
+        Entry::make()
+            ->id('allo-mate-idee')
+            ->collection('albums')
+            ->slug('allo-mate')
+            ->data([
+                'title' => 'Allo Mate!',
+                'artist' => 'Guvna B',
+                'things' => [
+                    [
+                        'text' => 'Woop die whoop!',
+                    ],
+                    [
+                        'text' => 'I have a Blue Peter badge!',
+                    ],
+                ],
+            ])
+            ->save();
+
+        $this
+            ->post(route('statamic.guest-entries.update'), [
+                '_collection' => 'albums',
+                '_id' => 'allo-mate-idee',
+                'record_label' => 'Unknown',
+            ])
+            ->assertRedirect();
+
+        $entry = Entry::find('allo-mate-idee');
+
+        $this->assertNotNull($entry);
+        $this->assertSame($entry->collectionHandle(), 'albums');
+        $this->assertSame($entry->get('title'), 'Allo Mate!');
+        $this->assertSame($entry->get('record_label'), 'Unknown');
+        $this->assertSame($entry->slug(), 'allo-mate');
+
+        $this->assertIsArray($entry->get('things'));
+        $this->assertCount(2, $entry->get('things'));
+    }
+
+    /** @test */
+    public function can_update_entry_with_replicator_field_and_an_assets_field_inside_the_replicator()
+    {
+        Blueprint::make('albums')
+            ->setNamespace('collections.albums')
+            ->setContents([
+                'title' => 'Albums',
+                'sections' => [
+                    'main' => [
+                        'display' => 'main',
+                        'fields' => [
+                            [
+                                'handle' => 'title',
+                                'field' => [
+                                    'type' => 'text',
+                                ],
+                            ],
+                            [
+                                'handle' => 'artist',
+                                'field' => [
+                                    'type' => 'text',
+                                ],
+                            ],
+                            [
+                                'handle' => 'slug',
+                                'field' => [
+                                    'type' => 'slug',
+                                ],
+                            ],
+                            [
+                                'handle' => 'record_label',
+                                'field' => [
+                                    'type' => 'text',
+                                ],
+                            ],
+                            [
+                                'handle' => 'things',
+                                'field' => [
+                                    'sets' => [
+                                        'thing' => [
+                                            'display' => 'Thing',
+                                            'fields' => [
+                                                [
+                                                    'handle' => 'link',
+                                                    'field' => [
+                                                        'type' => 'text',
+                                                    ],
+                                                ],
+                                                [
+                                                    'handle' => 'document',
+                                                    'field' => [
+                                                        'mode' => 'list',
+                                                        'container' => 'assets',
+                                                        'restrict' => false,
+                                                        'allow_uploads' => true,
+                                                        'show_filename' => true,
+                                                        'display' => 'Document',
+                                                        'type' => 'assets',
+                                                        'icon' => 'assets',
+                                                        'listable' => 'hidden',
+                                                        'max_items' => 1,
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                    'type' => 'replicator',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+            ->save();
+
+        Collection::make('albums')->save();
+
+        Entry::make()
+            ->id('allo-mate-idee')
+            ->collection('albums')
+            ->slug('allo-mate')
+            ->data([
+                'title' => 'Allo Mate!',
+                'artist' => 'Guvna B',
+            ])
+            ->save();
+
+        $this
+            ->post(route('statamic.guest-entries.update'), [
+                '_collection' => 'albums',
+                '_id' => 'allo-mate-idee',
+                'record_label' => 'Unknown',
+                'things' => [
+                    [
+                        'text' => 'Woop die whoop!',
+                    ],
+                    [
+                        'document' => UploadedFile::fake()->create('document.pdf', 100),
+                    ],
+                ],
+            ])
+            ->assertRedirect();
+
+        $entry = Entry::find('allo-mate-idee');
+
+        $this->assertNotNull($entry);
+        $this->assertSame($entry->collectionHandle(), 'albums');
+        $this->assertSame($entry->get('title'), 'Allo Mate!');
+        $this->assertSame($entry->get('record_label'), 'Unknown');
+        $this->assertSame($entry->slug(), 'allo-mate');
+
+        $this->assertIsArray($entry->get('things'));
+        $this->assertCount(2, $entry->get('things'));
+
+        $this->assertIsString($entry->get('things')[0]['text']);
+        $this->assertIsString($entry->get('things')[1]['document']);
     }
 
     /** @test */


### PR DESCRIPTION
This pull request implements a fix to allow for file uploads to be done inside Replicator sets. It includes some tests to ensure everything is saved correctly.

Fixes #33