### PR TITLE
Put success into the session

### DIFF
--- a/src/Http/Controllers/GuestEntryController.php
+++ b/src/Http/Controllers/GuestEntryController.php
@@ -74,7 +74,9 @@ class GuestEntryController extends Controller
 
         event(new GuestEntryCreated($entry));
 
-        return $this->withSuccess($request);
+        return $this->withSuccess($request, [
+            'success' => true,
+        ]);
     }
 
     public function update(UpdateRequest $request)
@@ -147,7 +149,9 @@ class GuestEntryController extends Controller
 
         event(new GuestEntryUpdated($entry));
 
-        return $this->withSuccess($request);
+        return $this->withSuccess($request, [
+            'success' => true,
+        ]);
     }
 
     public function destroy(DestroyRequest $request)
@@ -162,7 +166,9 @@ class GuestEntryController extends Controller
 
         event(new GuestEntryDeleted($entry));
 
-        return $this->withSuccess($request);
+        return $this->withSuccess($request, [
+            'success' => true,
+        ]);
     }
 
     protected function processField(Field $field, $key, $value, $request): mixed

--- a/tests/Http/Controllers/GuestEntryControllerTest.php
+++ b/tests/Http/Controllers/GuestEntryControllerTest.php
@@ -36,7 +36,8 @@ it('can store entry', function () {
             'title' => 'This is great',
             'slug' => 'this-is-great',
         ])
-        ->assertRedirect();
+        ->assertRedirect()
+        ->assertSessionHas('success');
 
     $entry = Entry::all()->last();
 
@@ -986,7 +987,8 @@ it('can update entry', function () {
             '_id' => 'allo-mate-idee',
             'record_label' => 'Unknown',
         ])
-        ->assertRedirect();
+        ->assertRedirect()
+        ->assertSessionHas('success');
 
     $entry = Entry::find('allo-mate-idee');
 
@@ -1948,11 +1950,12 @@ it('can destroy entry', function () {
             ->save();
 
     $this
-            ->delete(route('statamic.guest-entries.destroy'), [
-                '_collection' => 'albums',
-                '_id' => 'allo-mate-idee',
-            ])
-            ->assertRedirect();
+        ->delete(route('statamic.guest-entries.destroy'), [
+            '_collection' => 'albums',
+            '_id' => 'allo-mate-idee',
+        ])
+        ->assertRedirect()
+        ->assertSessionHas('success');
 
     $entry = Entry::find('allo-mate-idee');
 


### PR DESCRIPTION
This pull request puts a `success` variable into the user's session after the Guest Entry form has been submitted successfully.

I thought this was already the case but it turns out we're only currently doing it if you're wanting a JSON response back from the controller.

Fixes #45