### PR TITLE
Fix `error_redirect` parameter

### DIFF
--- a/src/Http/Controllers/GuestEntryController.php
+++ b/src/Http/Controllers/GuestEntryController.php
@@ -341,18 +341,4 @@ class GuestEntryController extends Controller
             redirect($request->_redirect)->with($data)
             : back()->with($data);
     }
-
-    protected function withErrors(Request $request, string $errorMessage)
-    {
-        if ($request->wantsJson()) {
-            return response()->json([
-                'status' => 'error',
-                'message' => $errorMessage,
-            ]);
-        }
-
-        return $request->_error_redirect
-            ? redirect($request->_error_redirect)->withErrors($errorMessage, 'guest-entries')
-            : back()->withErrors($errorMessage, 'guest-entries');
-    }
 }

--- a/src/Http/Requests/Concerns/HandleFailedValidation.php
+++ b/src/Http/Requests/Concerns/HandleFailedValidation.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace DoubleThreeDigital\GuestEntries\Http\Requests\Concerns;
+
+trait HandleFailedValidation
+{
+    /**
+     * Get the URL to redirect to on a validation error.
+     *
+     * @return string
+     */
+    protected function getRedirectUrl()
+    {
+        if ($this->has('_error_redirect')) {
+            return $this->get('_error_redirect');
+        }
+
+        return parent::getRedirectUrl();
+    }
+}

--- a/src/Http/Requests/DestroyRequest.php
+++ b/src/Http/Requests/DestroyRequest.php
@@ -8,7 +8,8 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class DestroyRequest extends FormRequest
 {
-    use Concerns\WhitelistedCollections;
+    use Concerns\WhitelistedCollections,
+        Concerns\HandleFailedValidation;
 
     public function authorize()
     {

--- a/src/Http/Requests/StoreRequest.php
+++ b/src/Http/Requests/StoreRequest.php
@@ -8,7 +8,8 @@ use Illuminate\Foundation\Http\FormRequest;
 class StoreRequest extends FormRequest
 {
     use Concerns\AcceptsFormRequests,
-        Concerns\WhitelistedCollections;
+        Concerns\WhitelistedCollections,
+        Concerns\HandleFailedValidation;
 
     public function authorize()
     {

--- a/src/Http/Requests/UpdateRequest.php
+++ b/src/Http/Requests/UpdateRequest.php
@@ -9,7 +9,8 @@ use Illuminate\Foundation\Http\FormRequest;
 class UpdateRequest extends FormRequest
 {
     use Concerns\AcceptsFormRequests,
-        Concerns\WhitelistedCollections;
+        Concerns\WhitelistedCollections,
+        Concerns\HandleFailedValidation;
 
     public function authorize()
     {

--- a/src/Tags/Concerns/FormBuilder.php
+++ b/src/Tags/Concerns/FormBuilder.php
@@ -82,8 +82,8 @@ trait FormBuilder
                 return $params[$param] = $redirect;
             }
         })->filter()
-        ->values()
-        ->all();
+            ->values()
+            ->all();
     }
 
     /**

--- a/src/Tags/Concerns/FormBuilder.php
+++ b/src/Tags/Concerns/FormBuilder.php
@@ -26,6 +26,10 @@ trait FormBuilder
             $html .= $this->redirectField();
         }
 
+        if ($this->params->get('error_redirect') != null) {
+            $html .= $this->errorRedirectField();
+        }
+
         if ($this->params->get('request') != null) {
             $html .= $this->requestField();
         }
@@ -59,6 +63,11 @@ trait FormBuilder
     private function redirectField()
     {
         return '<input type="hidden" name="_redirect" value="'.$this->params->get('redirect').'" />';
+    }
+
+    private function errorRedirectField()
+    {
+        return '<input type="hidden" name="_error_redirect" value="'.$this->params->get('error_redirect').'" />';
     }
 
     private function requestField()

--- a/tests/Http/Controllers/GuestEntryControllerTest.php
+++ b/tests/Http/Controllers/GuestEntryControllerTest.php
@@ -119,14 +119,14 @@ it('can store entry and ensure ignored parameters are not saved', function () {
     Collection::make('comments')->save();
 
     $this
-            ->post(route('statamic.guest-entries.store'), [
-                '_collection' => 'comments',
-                '_redirect' => '/whatever',
-                '_error_redirect' => '/whatever-else',
-                'title' => 'This is great',
-                'slug' => 'this-is-great',
-            ])
-            ->assertRedirect();
+        ->post(route('statamic.guest-entries.store'), [
+            '_collection' => 'comments',
+            '_redirect' => '/whatever',
+            '_error_redirect' => '/whatever-else',
+            'title' => 'This is great',
+            'slug' => 'this-is-great',
+        ])
+        ->assertRedirect();
 
     $entry = Entry::all()->last();
 
@@ -449,60 +449,60 @@ it('can store entry and ensure multiple files can be uploaded', function () {
     AssetContainer::make('assets')->disk('local')->save();
 
     Blueprint::make('comments')
-            ->setNamespace('collections.comments')
-            ->setContents([
-                'title' => 'Comments',
-                'sections' => [
-                    'main' => [
-                        'display' => 'main',
-                        'fields' => [
-                            [
-                                'handle' => 'title',
-                                'field' => [
-                                    'type' => 'text',
-                                ],
+        ->setNamespace('collections.comments')
+        ->setContents([
+            'title' => 'Comments',
+            'sections' => [
+                'main' => [
+                    'display' => 'main',
+                    'fields' => [
+                        [
+                            'handle' => 'title',
+                            'field' => [
+                                'type' => 'text',
                             ],
-                            [
-                                'handle' => 'slug',
-                                'field' => [
-                                    'type' => 'slug',
-                                ],
+                        ],
+                        [
+                            'handle' => 'slug',
+                            'field' => [
+                                'type' => 'slug',
                             ],
-                            [
-                                'handle' => 'attachments',
-                                'field' => [
-                                    'mode' => 'list',
-                                    'container' => 'assets',
-                                    'restrict' => false,
-                                    'allow_uploads' => true,
-                                    'show_filename' => true,
-                                    'display' => 'Attachment',
-                                    'type' => 'assets',
-                                    'icon' => 'assets',
-                                    'listable' => 'hidden',
-                                ],
+                        ],
+                        [
+                            'handle' => 'attachments',
+                            'field' => [
+                                'mode' => 'list',
+                                'container' => 'assets',
+                                'restrict' => false,
+                                'allow_uploads' => true,
+                                'show_filename' => true,
+                                'display' => 'Attachment',
+                                'type' => 'assets',
+                                'icon' => 'assets',
+                                'listable' => 'hidden',
                             ],
                         ],
                     ],
                 ],
-            ])
-            ->save();
+            ],
+        ])
+        ->save();
 
     Collection::make('comments')->save();
 
     $this->withoutExceptionHandling();
 
     $this
-            ->post(route('statamic.guest-entries.store'), [
-                '_collection' => 'comments',
-                'title' => 'This is great',
-                'slug' => 'this-is-great',
-                'attachments' => [
-                    UploadedFile::fake()->create('foobar.png'),
-                    UploadedFile::fake()->create('barfoo.jpg'),
-                ],
-            ])
-            ->assertRedirect();
+        ->post(route('statamic.guest-entries.store'), [
+            '_collection' => 'comments',
+            'title' => 'This is great',
+            'slug' => 'this-is-great',
+            'attachments' => [
+                UploadedFile::fake()->create('foobar.png'),
+                UploadedFile::fake()->create('barfoo.jpg'),
+            ],
+        ])
+        ->assertRedirect();
 
     $entry = Entry::all()->last();
 
@@ -1940,14 +1940,14 @@ it('can destroy entry', function () {
     Collection::make('albums')->save();
 
     Entry::make()
-            ->id('allo-mate-idee')
-            ->collection('albums')
-            ->slug('allo-mate')
-            ->data([
-                'title' => 'Allo Mate!',
-                'artist' => 'Guvna B',
-            ])
-            ->save();
+        ->id('allo-mate-idee')
+        ->collection('albums')
+        ->slug('allo-mate')
+        ->data([
+            'title' => 'Allo Mate!',
+            'artist' => 'Guvna B',
+        ])
+        ->save();
 
     $this
         ->delete(route('statamic.guest-entries.destroy'), [

--- a/tests/Tags/GuestEntriesTagTest.php
+++ b/tests/Tags/GuestEntriesTagTest.php
@@ -81,6 +81,24 @@ it('throws an exception when attempting to return create guest entry form when c
     $usage = $tag->create();
 })->throws(CollectionNotFoundException::class);
 
+it('returns create guest entry form with redirect and error_redirect hidden inputs', function () use (&$tag) {
+    Collection::make('guestbook')->save();
+
+    $tag->setParameters([
+        'collection' => 'guestbook',
+        'redirect' => '/thank-you',
+        'error_redirect' => '/error',
+    ]);
+
+    $usage = $tag->create();
+
+    assertStringContainsString('http://localhost/!/guest-entries/create', $usage);
+    assertStringContainsString('<input type="hidden" name="_token"', $usage);
+    assertStringContainsString('<input type="hidden" name="_collection" value="guestbook"', $usage);
+    assertStringContainsString('<input type="hidden" name="_redirect" value="/thank-you"', $usage);
+    assertStringContainsString('<input type="hidden" name="_error_redirect" value="/error"', $usage);
+});
+
 it('returns update guest entry form', function () use (&$tag) {
     Collection::make('guestbook')->save();
 
@@ -263,6 +281,33 @@ it('returns update guest entry form and entry values can be used', function () u
     assertStringContainsString('<textarea name="comment">Something can go here</textarea>', $usage);
 });
 
+it('returns update guest entry form with redirect and error_redirect hidden inputs', function () use (&$tag) {
+    Collection::make('guestbook')->save();
+
+    Entry::make()
+        ->collection('guestbook')
+        ->id('hello')
+        ->slug('hello')
+        ->data(['title' => 'Hello World'])
+        ->save();
+
+    $tag->setParameters([
+        'collection' => 'guestbook',
+        'id' => 'hello',
+        'redirect' => '/thank-you',
+        'error_redirect' => '/error',
+    ]);
+
+    $usage = $tag->update();
+
+    assertStringContainsString('http://localhost/!/guest-entries/update', $usage);
+    assertStringContainsString('<input type="hidden" name="_token"', $usage);
+    assertStringContainsString('<input type="hidden" name="_collection" value="guestbook"', $usage);
+    assertStringContainsString('<input type="hidden" name="_id" value="hello"', $usage);
+    assertStringContainsString('<input type="hidden" name="_redirect" value="/thank-you"', $usage);
+    assertStringContainsString('<input type="hidden" name="_error_redirect" value="/error"', $usage);
+});
+
 it('returns delete guest entry form', function () use (&$tag) {
     Collection::make('guestbook')->save();
 
@@ -419,4 +464,31 @@ it('returns delete guest entry form and entry values can be used', function () u
 
     assertStringContainsString('<h2>Delete Guestbook Entry: Hello World</h2>', $usage);
     assertStringContainsString('<button type="submit">DELETE</button>', $usage);
+});
+
+it('returns delete guest entry form with redirect and error_redirect hidden inputs', function () use (&$tag) {
+    Collection::make('guestbook')->save();
+
+    Entry::make()
+        ->collection('guestbook')
+        ->id('hello')
+        ->slug('hello')
+        ->data(['title' => 'Hello World'])
+        ->save();
+
+    $tag->setParameters([
+        'collection' => 'guestbook',
+        'id' => 'hello',
+        'redirect' => '/thank-you',
+        'error_redirect' => '/error',
+    ]);
+
+    $usage = $tag->delete();
+
+    assertStringContainsString('http://localhost/!/guest-entries/delete', $usage);
+    assertStringContainsString('<input type="hidden" name="_token"', $usage);
+    assertStringContainsString('<input type="hidden" name="_collection" value="guestbook"', $usage);
+    assertStringContainsString('<input type="hidden" name="_id" value="hello"', $usage);
+    assertStringContainsString('<input type="hidden" name="_redirect" value="/thank-you"', $usage);
+    assertStringContainsString('<input type="hidden" name="_error_redirect" value="/error"', $usage);
 });


### PR DESCRIPTION
This pull request implements the `error_redirect` parameter properly.

The parameter was documented and I always thought it existed. However, it seems no hidden form parameter was created for it, like one is when you use the `redirect` parameter.

We also didn't have code to take the user to that URL when validation fails. There was a method in the controller for it but it wasn't being used.

Fixes #49