### PR TITLE
Add `{{ guest-entries:success }}` tag

### DIFF
--- a/docs/tags.md
+++ b/docs/tags.md
@@ -106,10 +106,10 @@ If you'd like to show any errors after a user has submitted the Guest Entries fo
 
 ### Success
 
-If you'd like to show a success message after a user has submitted a Guest entry, you can test for the session success key. 
+If you'd like to show a success message after a user has submitted the Guest Entries form, you can use the `{{ guest-entries:success }}` tag, like shown below:
 
 ```antlers
-{{ if {session:has key="success"} }}
+{{ if {guest-entries:success} }}
     Well done buddy!
 {{ /if }}
 ```

--- a/src/Http/Controllers/GuestEntryController.php
+++ b/src/Http/Controllers/GuestEntryController.php
@@ -333,6 +333,8 @@ class GuestEntryController extends Controller
             return response()->json($data);
         }
 
+        $request->session()->put('guest-entries.success', true);
+
         return $request->_redirect ?
             redirect($request->_redirect)->with($data)
             : back()->with($data);

--- a/src/Http/Controllers/GuestEntryController.php
+++ b/src/Http/Controllers/GuestEntryController.php
@@ -76,9 +76,7 @@ class GuestEntryController extends Controller
 
         event(new GuestEntryCreated($entry));
 
-        return $this->withSuccess($request, [
-            'success' => true,
-        ]);
+        return $this->withSuccess($request);
     }
 
     public function update(UpdateRequest $request)
@@ -151,9 +149,7 @@ class GuestEntryController extends Controller
 
         event(new GuestEntryUpdated($entry));
 
-        return $this->withSuccess($request, [
-            'success' => true,
-        ]);
+        return $this->withSuccess($request);
     }
 
     public function destroy(DestroyRequest $request)
@@ -168,9 +164,7 @@ class GuestEntryController extends Controller
 
         event(new GuestEntryDeleted($entry));
 
-        return $this->withSuccess($request, [
-            'success' => true,
-        ]);
+        return $this->withSuccess($request);
     }
 
     protected function processField(Field $field, $key, $value, $request): mixed

--- a/src/Tags/GuestEntriesTag.php
+++ b/src/Tags/GuestEntriesTag.php
@@ -97,4 +97,9 @@ class GuestEntriesTag extends Tags
     {
         return session()->has('errors');
     }
+
+    public function success(): bool
+    {
+        return session()->get('guest-entries.success', false);
+    }
 }

--- a/tests/Http/Controllers/GuestEntryControllerTest.php
+++ b/tests/Http/Controllers/GuestEntryControllerTest.php
@@ -36,8 +36,7 @@ it('can store entry', function () {
             'title' => 'This is great',
             'slug' => 'this-is-great',
         ])
-        ->assertRedirect()
-        ->assertSessionHas('success');
+        ->assertRedirect();
 
     $entry = Entry::all()->last();
 
@@ -1006,8 +1005,7 @@ it('can update entry', function () {
             '_id' => 'allo-mate-idee',
             'record_label' => 'Unknown',
         ])
-        ->assertRedirect()
-        ->assertSessionHas('success');
+        ->assertRedirect();
 
     $entry = Entry::find('allo-mate-idee');
 
@@ -2000,12 +1998,11 @@ it('can destroy entry', function () {
         ->save();
 
     $this
-        ->delete(route('statamic.guest-entries.destroy'), [
-            '_collection' => 'albums',
-            '_id' => 'allo-mate-idee',
-        ])
-        ->assertRedirect()
-        ->assertSessionHas('success');
+            ->delete(route('statamic.guest-entries.destroy'), [
+                '_collection' => 'albums',
+                '_id' => 'allo-mate-idee',
+            ])
+            ->assertRedirect();
 
     $entry = Entry::find('allo-mate-idee');
 

--- a/tests/Http/Controllers/GuestEntryControllerTest.php
+++ b/tests/Http/Controllers/GuestEntryControllerTest.php
@@ -1998,11 +1998,11 @@ it('can destroy entry', function () {
         ->save();
 
     $this
-            ->delete(route('statamic.guest-entries.destroy'), [
-                '_collection' => 'albums',
-                '_id' => 'allo-mate-idee',
-            ])
-            ->assertRedirect();
+        ->delete(route('statamic.guest-entries.destroy'), [
+            '_collection' => 'albums',
+            '_id' => 'allo-mate-idee',
+        ])
+        ->assertRedirect();
 
     $entry = Entry::find('allo-mate-idee');
 


### PR DESCRIPTION
This pull request reverts #47 where I put a `success` key into the session as it conflicts if another form also puts that into the session.

Instead, I'm copying the [`{{ form:success }}`](https://statamic.dev/tags/form-success#content) tag included in Statamic, so you can do something like this instead to show success messages:

```antlers
{{ if {guest-entries:success} }}
    Well done buddy!
{{ /if }}
```

Fixes #48