### PR TITLE
Blade Compatibility

### DIFF
--- a/docs/tags.md
+++ b/docs/tags.md
@@ -2,7 +2,7 @@
 title: Tags
 ---
 
-### Create Entry
+## Create Entry
 
 ```antlers
 {{ guest-entries:create collection="articles" }}
@@ -15,7 +15,7 @@ title: Tags
 {{ /guest-entries:create }}
 ```
 
-### Update Entry
+## Update Entry
 
 ```antlers
 {{ guest-entries:update collection="articles" id="article-id" }}
@@ -28,7 +28,7 @@ title: Tags
 {{ /guest-entries:update }}
 ```
 
-### Delete Entry
+## Delete Entry
 
 ```antlers
 {{ guest-entries:delete collection="articles" id="article-id" }}
@@ -39,7 +39,7 @@ title: Tags
 {{ /guest-entries:delete }}
 ```
 
-### Parameters
+## Parameters
 
 When using any of the `guest-entries` tags, there's a few parameters available to you:
 
@@ -63,7 +63,7 @@ You may specify a URL to redirect the user to once the Guest Entry form has been
 
 You may specify a Laravel Form Request to be used for validation of the form. You can pass in simply the name of the class or the FQNS (fully qualified namespace) - eg. `ArticleStoreRequest` vs `App\Http\Requests\ArticleStoreRequest`
 
-### Special Inputs
+## Special Inputs
 
 There's a few 'special' input fields that you can take advantage of:
 
@@ -81,7 +81,7 @@ Pretty self-explanatory. Allows you to control the publish state of the created 
 
 When not provided, the entry will be set to unpublished.
 
-### Variables
+## Variables
 
 If you're using the update/delete forms provided by Guest Entries, you will be able to use any of your entries data, in case you wish to fill `value` attributes on the input fields.
 
@@ -94,7 +94,7 @@ If you're using the update/delete forms provided by Guest Entries, you will be a
 {{ /guest-entries:update }}
 ```
 
-### Errors
+## Errors
 
 If you'd like to show any errors after a user has submitted the Guest Entries form, you can use the `{{ guest-entries:errors }}` tag, like shown below:
 
@@ -104,7 +104,7 @@ If you'd like to show any errors after a user has submitted the Guest Entries fo
 {{ /guest-entries:errors }}
 ```
 
-### Success
+## Success
 
 If you'd like to show a success message after a user has submitted the Guest Entries form, you can use the `{{ guest-entries:success }}` tag, like shown below:
 
@@ -113,3 +113,28 @@ If you'd like to show a success message after a user has submitted the Guest Ent
     Well done buddy!
 {{ /if }}
 ```
+
+## Using with Blade
+
+You can still use the tags provided by Guest Entries in Blade. However, they'll work slightly differently. Instead of Guest Entries constructing the HTML of the `<form>` for you, you need to construct the HTML yourself.
+
+Thankfully, it's an easy process:
+
+```blade
+@php
+$form = Statamic::tag('guest-entries:update')->params([
+    'collection' => 'articles',
+    'id' => 'id-of-entry',
+])->fetch();
+@endphp
+
+<form {!! $form['attrs_html'] !!}>
+    {!! $form['params_html'] !!}
+    <input type="text" name="description" />
+    <button>Update article</button>
+</form>
+```
+
+The above example uses the `{{ guest-entries:update }}` form. You simply use the `{!! $form['attrs_html'] !!}` in the `<form>` tag (this adds the `action` and `method` attributes). Then, somewhere inside the form, add the hidden parameters with `{!! $form['params_html'] !!}`.
+
+Make sure to pass in any required parameters in the `->params([])` array.

--- a/src/Tags/GuestEntriesTag.php
+++ b/src/Tags/GuestEntriesTag.php
@@ -14,7 +14,6 @@ class GuestEntriesTag extends Tags
 
     protected static $handle = 'guest-entries';
 
-    // {{ guest-entries:create collection="name" }} <input type="hidden" name="title" value="Whatever..."> {{ /guest-entries }}
     public function create()
     {
         $collectionHandle = $this->params->get('collection');
@@ -27,7 +26,9 @@ class GuestEntriesTag extends Tags
             throw new CollectionNotFoundException($collectionHandle);
         }
 
-        return $this->createForm(route('statamic.guest-entries.store'));
+        return $this->createForm(
+            route('statamic.guest-entries.store')
+        );
     }
 
     public function update()
@@ -51,7 +52,10 @@ class GuestEntriesTag extends Tags
             throw new EntryNotFoundException();
         }
 
-        return $this->createForm(route('statamic.guest-entries.update'), Entry::find($entryId)->data()->toArray());
+        return $this->createForm(
+            route('statamic.guest-entries.update'),
+            Entry::find($entryId)->data()->toArray()
+        );
     }
 
     public function delete()
@@ -75,7 +79,11 @@ class GuestEntriesTag extends Tags
             throw new EntryNotFoundException();
         }
 
-        return $this->createForm(route('statamic.guest-entries.destroy'), Entry::find($entryId)->data()->toArray(), 'DELETE');
+        return $this->createForm(
+            route('statamic.guest-entries.destroy'),
+            Entry::find($entryId)->data()->toArray(),
+            'DELETE'
+        );
     }
 
     public function errors()

--- a/tests/Http/Controllers/GuestEntryControllerTest.php
+++ b/tests/Http/Controllers/GuestEntryControllerTest.php
@@ -197,7 +197,7 @@ it('can store entry where collection is date ordered and ensure date is saved', 
     $this->assertSame($entry->get('title'), 'This is great');
     $this->assertSame($entry->slug(), 'this-is-great');
 
-    $this->assertStringContainsString('2021-10-10.this-is-great.md', $entry->path());
+    $this->assertStringContainsString('2021-10-10-1111.this-is-great.md', $entry->path());
 });
 
 it('can store entry where collection is not date ordered and ensure date is saved', function () {

--- a/tests/Http/Controllers/GuestEntryControllerTest.php
+++ b/tests/Http/Controllers/GuestEntryControllerTest.php
@@ -197,7 +197,7 @@ it('can store entry where collection is date ordered and ensure date is saved', 
     $this->assertSame($entry->get('title'), 'This is great');
     $this->assertSame($entry->slug(), 'this-is-great');
 
-    $this->assertStringContainsString('2021-10-10-1111.this-is-great.md', $entry->path());
+    $this->assertStringContainsString('2021-10-10.this-is-great.md', $entry->path());
 });
 
 it('can store entry where collection is not date ordered and ensure date is saved', function () {

--- a/tests/Tags/GuestEntriesTagTest.php
+++ b/tests/Tags/GuestEntriesTagTest.php
@@ -7,6 +7,7 @@ use Statamic\Exceptions\CollectionNotFoundException;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
+use Statamic\Statamic;
 use Statamic\Tags\Tags;
 
 $tag = null;
@@ -308,6 +309,28 @@ it('returns update guest entry form with redirect and error_redirect hidden inpu
     assertStringContainsString('<input type="hidden" name="_error_redirect" value="/error"', $usage);
 });
 
+it('can fetch update guest entry form data', function () {
+    Collection::make('guestbook')->save();
+
+    Entry::make()
+        ->collection('guestbook')
+        ->id('hello')
+        ->slug('hello')
+        ->data(['title' => 'Hello World'])
+        ->save();
+
+    $form = Statamic::tag('guest-entries:update')->params([
+        'collection' => 'guestbook',
+        'id' => 'hello',
+    ])->fetch();
+
+    assertStringContainsString('http://localhost/!/guest-entries/update', $form['attrs_html']);
+    assertStringContainsString('<input type="hidden" name="_token"', $form['params_html']);
+    assertStringContainsString('<input type="hidden" name="_collection" value="guestbook"', $form['params_html']);
+    assertStringContainsString('<input type="hidden" name="_id" value="hello"', $form['params_html']);
+    assertStringContainsString('Hello World', $form['title']);
+});
+
 it('returns delete guest entry form', function () use (&$tag) {
     Collection::make('guestbook')->save();
 
@@ -491,4 +514,26 @@ it('returns delete guest entry form with redirect and error_redirect hidden inpu
     assertStringContainsString('<input type="hidden" name="_id" value="hello"', $usage);
     assertStringContainsString('<input type="hidden" name="_redirect" value="/thank-you"', $usage);
     assertStringContainsString('<input type="hidden" name="_error_redirect" value="/error"', $usage);
+});
+
+it('can fetch delete guest entry form data', function () {
+    Collection::make('guestbook')->save();
+
+    Entry::make()
+        ->collection('guestbook')
+        ->id('hello')
+        ->slug('hello')
+        ->data(['title' => 'Hello World'])
+        ->save();
+
+    $form = Statamic::tag('guest-entries:delete')->params([
+        'collection' => 'guestbook',
+        'id' => 'hello',
+    ])->fetch();
+
+    assertStringContainsString('http://localhost/!/guest-entries/delete', $form['attrs_html']);
+    assertStringContainsString('<input type="hidden" name="_token"', $form['params_html']);
+    assertStringContainsString('<input type="hidden" name="_collection" value="guestbook"', $form['params_html']);
+    assertStringContainsString('<input type="hidden" name="_id" value="hello"', $form['params_html']);
+    assertStringContainsString('Hello World', $form['title']);
 });


### PR DESCRIPTION
This pull request implements compatibility for using the Guest Entries addon in Blade, copied from duncanmcclean/simple-commerce#792.

## Example

```blade
@php
$form = Statamic::tag('guest-entries:update')->params([
    'collection' => 'articles',
    'id' => 'id-of-entry',
])->fetch();
@endphp

<form {!! $form['attrs_html'] !!}>
    {!! $form['params_html'] !!}
    <input type="text" name="description" />
    <button>Update article</button>
</form>
```