### PR TITLE
Fix success message being shown permanently

### DIFF
--- a/src/Http/Controllers/GuestEntryController.php
+++ b/src/Http/Controllers/GuestEntryController.php
@@ -333,7 +333,7 @@ class GuestEntryController extends Controller
             return response()->json($data);
         }
 
-        $request->session()->put('guest-entries.success', true);
+        $request->session()->flash('guest-entries.success', true);
 
         return $request->_redirect ?
             redirect($request->_redirect)->with($data)


### PR DESCRIPTION
This pull request fixes an issue where the success message on forms would always show if the user had previously submitted a form.

This was happening as I wasn't "flashing" the success key into the cache, I was putting it there forever 🙈 

Fixes #58