### PR TITLE
Prevent uploading .php files

### DIFF
--- a/src/Http/Requests/DestroyRequest.php
+++ b/src/Http/Requests/DestroyRequest.php
@@ -8,8 +8,8 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class DestroyRequest extends FormRequest
 {
-    use Concerns\WhitelistedCollections,
-        Concerns\HandleFailedValidation;
+    use Concerns\HandleFailedValidation,
+        Concerns\WhitelistedCollections;
 
     public function authorize()
     {

--- a/src/Http/Requests/StoreRequest.php
+++ b/src/Http/Requests/StoreRequest.php
@@ -9,8 +9,8 @@ use Statamic\Facades\Collection;
 class StoreRequest extends FormRequest
 {
     use Concerns\AcceptsFormRequests,
-        Concerns\WhitelistedCollections,
-        Concerns\HandleFailedValidation;
+        Concerns\HandleFailedValidation,
+        Concerns\WhitelistedCollections;
 
     public function authorize()
     {

--- a/src/Http/Requests/UpdateRequest.php
+++ b/src/Http/Requests/UpdateRequest.php
@@ -9,8 +9,8 @@ use Illuminate\Foundation\Http\FormRequest;
 class UpdateRequest extends FormRequest
 {
     use Concerns\AcceptsFormRequests,
-        Concerns\WhitelistedCollections,
-        Concerns\HandleFailedValidation;
+        Concerns\HandleFailedValidation,
+        Concerns\WhitelistedCollections;
 
     public function authorize()
     {

--- a/tests/Tags/GuestEntriesTagTest.php
+++ b/tests/Tags/GuestEntriesTagTest.php
@@ -3,13 +3,14 @@
 use DuncanMcClean\GuestEntries\Tags\GuestEntriesTag;
 use Illuminate\Container\EntryNotFoundException;
 use Illuminate\Support\Facades\Config;
-use function PHPUnit\Framework\assertStringContainsString;
 use Statamic\Exceptions\CollectionNotFoundException;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Statamic;
 use Statamic\Tags\Tags;
+
+use function PHPUnit\Framework\assertStringContainsString;
 
 $tag = null;
 


### PR DESCRIPTION
This pull request implements a fix to prevent `.php` files from being uploaded via Guest Entry forms.