### PR TITLE
Add to list of PHP file extensions

### DIFF
--- a/src/Http/Controllers/GuestEntryController.php
+++ b/src/Http/Controllers/GuestEntryController.php
@@ -244,7 +244,7 @@ class GuestEntryController extends Controller
 
         $uploadedFiles = collect($uploadedFiles)
             ->each(function ($file) use ($key) {
-                if (in_array(trim(strtolower($file->getClientOriginalExtension())), ['php', 'php3', 'php4', 'php5', 'phtml'])) {
+                if (in_array(trim(strtolower($file->getClientOriginalExtension())), ['php', 'php3', 'php4', 'php5', 'php7', 'php8', 'phtml', 'phar'])) {
                     $validator = Validator::make([], []);
                     $validator->errors()->add($key, __('Failed to upload.'));
 


### PR DESCRIPTION
This pull request adds another few PHP file extensions to the list that were blacklisted in #60.

This mirrors the recent change to add new file extensions to the blacklist in Statamic Core - see https://github.com/statamic/cms/pull/8991.

