### PR TITLE
[6.x] File Upload Security fixes

### DIFF
--- a/src/Http/Controllers/GuestEntryController.php
+++ b/src/Http/Controllers/GuestEntryController.php
@@ -26,6 +26,7 @@ use Statamic\Fieldtypes\Assets\Assets as AssetFieldtype;
 use Statamic\Fieldtypes\Date as DateFieldtype;
 use Statamic\Fieldtypes\Replicator;
 use Statamic\Sites\Site;
+use Statamic\Validation\AllowedFile;
 
 class GuestEntryController extends Controller
 {
@@ -244,11 +245,12 @@ class GuestEntryController extends Controller
 
         $uploadedFiles = collect($uploadedFiles)
             ->each(function ($file) use ($key) {
-                if (in_array(trim(strtolower($file->getClientOriginalExtension())), ['php', 'php3', 'php4', 'php5', 'php7', 'php8', 'phtml', 'phar'])) {
-                    $validator = Validator::make([], []);
-                    $validator->errors()->add($key, __('Failed to upload.'));
+                $validator = Validator::make([$key => $file], [
+                    $key => ['file', new AllowedFile],
+                ]);
 
-                    throw new ValidationException($validator);
+                if ($validator->fails()) {
+                    throw ValidationException::withMessages($validator->errors()->toArray());
                 }
             })
             ->filter()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -47,7 +47,7 @@ abstract class TestCase extends OrchestraTestCase
         ];
 
         foreach ($configs as $config) {
-            $app['config']->set("statamic.$config", require(__DIR__."/../vendor/statamic/cms/config/{$config}.php"));
+            $app['config']->set("statamic.$config", require (__DIR__."/../vendor/statamic/cms/config/{$config}.php"));
         }
 
         $app['config']->set('statamic.users.repository', 'file');


### PR DESCRIPTION
This pull request makes some security-related fixes to the File Uploads feature.

* Users will only be able to upload certain file extensions, rather than any old file extension.
    * This replaces the previous fix in #60 which prevented _just_ `.php` files
    * Related PR in Statamic Core: https://github.com/statamic/cms/pull/9037
* SVG file uploads are now sanitized.
    * Related PR in Statamic Core: https://github.com/statamic/cms/pull/9365