### PR TITLE
[4.x] Ensure date is only filled when provided in request

### DIFF
--- a/src/Http/Controllers/GuestEntryController.php
+++ b/src/Http/Controllers/GuestEntryController.php
@@ -215,16 +215,12 @@ class GuestEntryController extends Controller
             $value = $this->uploadFile($key, $field, $request);
         }
 
-        if (
-            $value
-            && $field
-            && $field->fieldtype() instanceof DateFieldtype
-        ) {
+        if ($value && $field && $field->fieldtype() instanceof DateFieldtype) {
             $format = $field->fieldtype()->config(
                 'format',
                 strlen($value) > 10 ? $field->fieldtype()::DEFAULT_DATETIME_FORMAT : $field->fieldtype()::DEFAULT_DATE_FORMAT
             );
-            
+
             $value = Carbon::parse($value)->format($format);
         }
 

--- a/src/Http/Controllers/GuestEntryController.php
+++ b/src/Http/Controllers/GuestEntryController.php
@@ -215,12 +215,16 @@ class GuestEntryController extends Controller
             $value = $this->uploadFile($key, $field, $request);
         }
 
-        if ($field && $field->fieldtype() instanceof DateFieldtype) {
+        if (
+            $value
+            && $field
+            && $field->fieldtype() instanceof DateFieldtype
+        ) {
             $format = $field->fieldtype()->config(
                 'format',
                 strlen($value) > 10 ? $field->fieldtype()::DEFAULT_DATETIME_FORMAT : $field->fieldtype()::DEFAULT_DATE_FORMAT
             );
-
+            
             $value = Carbon::parse($value)->format($format);
         }
 


### PR DESCRIPTION
This pull request fixes an issue with Date fields in the create & update forms, where when the user didn't provide a date in the form, Guest Entries would have defaulted to the current date instead of not setting one at all.

This was happening since `$value` was `null` but `Carbon::parse()` returns the current date when a null value is passed.

Fixes #67.