### PR TITLE
Form Request Authorization

### DIFF
--- a/src/Http/Requests/StoreRequest.php
+++ b/src/Http/Requests/StoreRequest.php
@@ -14,7 +14,19 @@ class StoreRequest extends FormRequest
 
     public function authorize()
     {
-        return $this->collectionIsWhitelisted($this->get('_collection'));
+        if (! $this->collectionIsWhitelisted($this->get('_collection'))) {
+            return false;
+        }
+
+        if ($formRequest = $this->get('_request')) {
+            $formRequest = $this->buildFormRequest($formRequest, $this);
+
+            if (method_exists($formRequest, 'authorize')) {
+                return $formRequest->authorize();
+            }
+        }
+
+        return true;
     }
 
     public function rules()

--- a/src/Http/Requests/UpdateRequest.php
+++ b/src/Http/Requests/UpdateRequest.php
@@ -14,7 +14,19 @@ class UpdateRequest extends FormRequest
 
     public function authorize()
     {
-        return $this->collectionIsWhitelisted($this->get('_collection'));
+        if (! $this->collectionIsWhitelisted($this->get('_collection'))) {
+            return false;
+        }
+
+        if ($formRequest = $this->get('_request')) {
+            $formRequest = $this->buildFormRequest($formRequest, $this);
+
+            if (method_exists($formRequest, 'authorize')) {
+                return $formRequest->authorize();
+            }
+        }
+
+        return true;
     }
 
     public function rules()


### PR DESCRIPTION
Currently, when you specify a form request to be used for a Guest Entries form, it'll only be used for `rules()` and `messages()`.

This pull request will call the `authorize()` methods on form requests, if they exist.