### PR TITLE
Supports Laravel 12

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         php: [8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*]
+        laravel: [10.*, 11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         exclude:

--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,6 @@
             "pixelfear/composer-dist-plugin": true,
             "pestphp/pest-plugin": true
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,5 @@
             "pixelfear/composer-dist-plugin": true,
             "pestphp/pest-plugin": true
         }
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "statamic/cms": "^5.41"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.28 || ^9.6.1",
         "pestphp/pest": "^2.2",
+        "orchestra/testbench": "^8.28 || ^9.6.1 || ^10.0",
         "spatie/test-time": "^1.2",
         "laravel/pint": "^1.18"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "statamic/cms": "^5.41"
     },
     "require-dev": {
-        "pestphp/pest": "^2.2",
+        "pestphp/pest": "^2.2 || ^3.0",
         "orchestra/testbench": "^8.28 || ^9.6.1 || ^10.0",
         "spatie/test-time": "^1.2",
         "laravel/pint": "^1.18"


### PR DESCRIPTION
This pull request adds Laravel 12 support to `duncanmcclean/guest-entries`.

Depends on:

* [x] https://github.com/statamic/cms/pull/11433