### PR TITLE
[5.x] Statamic 6

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,13 +12,10 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.3, 8.4]
+        laravel: [11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
-        exclude:
-          - php: 8.4
-            laravel: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": "^8.2",
-        "statamic/cms": "^5.41"
+        "statamic/cms": "dev-master"
     },
     "require-dev": {
         "pestphp/pest": "^2.2 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "statamic/cms": "dev-master"
     },
     "require-dev": {
-        "pestphp/pest": "^2.2 || ^3.0",
-        "orchestra/testbench": "^8.28 || ^9.6.1 || ^10.0",
+        "pestphp/pest": "^3.0",
+        "orchestra/testbench": "^9.6.1 || ^10.0",
         "spatie/test-time": "^1.2",
         "laravel/pint": "^1.18"
     },


### PR DESCRIPTION
This pull request adds support for Statamic 6, which is currently due to be released [~July 2025](https://statamic.dev/release-schedule-support-policy#support-policy).